### PR TITLE
Set glowpad opacity to 50%

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -62,8 +62,8 @@
 
     <color name="translucent_shadow">#33999999</color>
 
-    <!-- 70% opacity, black. -->
-    <color name="glowpad_background_color">#b3000000</color>
+    <!-- 50% opacity, black. -->
+    <color name="glowpad_background_color">#80000000</color>
     <!-- 15% opacity, white. -->
     <color name="glowpad_outer_ring_color">#26ffffff</color>
     <color name="glowpad_text_widget_ring_color">#ffffff</color>


### PR DESCRIPTION
Current 70% opacitiy is pretty dark. Some photos are very hard to show, si decrease this value little bit.

Signed-off-by: Petr kecinzer Řezníček kecinzer@gmail.com
